### PR TITLE
Implemented methods to close apple pay sheet with success or error

### DIFF
--- a/lib/flutter_apple_pay.dart
+++ b/lib/flutter_apple_pay.dart
@@ -8,7 +8,7 @@ class FlutterApplePay {
   static const MethodChannel _channel =
       const MethodChannel('flutter_apple_pay');
 
-  static Future<dynamic> makePayment({
+  static Future<dynamic> getStripeToken({
     @required String countryCode,
     @required String currencyCode,
     @required List<PaymentNetwork> paymentNetworks,
@@ -34,8 +34,21 @@ class FlutterApplePay {
       'merchantIdentifier': merchantIdentifier
     };
     if (Platform.isIOS) {
-      final dynamic version = await _channel.invokeMethod('', args);
-      return version;
+      final dynamic stripeToken = await _channel.invokeMethod('getStripeToken', args);
+      return stripeToken;
+    } else {
+      throw Exception("Not supported operation system");
+    }
+  }
+
+  static Future<void> closeApplePaySheet({@required bool isSuccess}) async {
+    if (Platform.isIOS) {
+      if(isSuccess) {
+        await _channel.invokeMethod('closeApplePaySheetWithSuccess');
+      }
+      else {
+        await _channel.invokeMethod('closeApplePaySheetWithError');
+      }
     } else {
       throw Exception("Not supported operation system");
     }


### PR DESCRIPTION
For proper use case we should only show success message on apple pay sheet when payment is processed but right now success message is shown when stripe token is generated.

I have added a new method closeApplePaySheet which accepts a bool parameter so that user can call this method later on when payment is processed.

Also, changed makeRequest method name to getStripeToken.

I am mainly js/flutter dev and hardly know swift, just experimenting with this plugin from last 2 days to get it working according to my requirements so there can be implementation issues. Feel free to point them out and we can merge it afterwards if you feels this can be helpful for plugin. 