### PR TITLE
App Review Requires Merchant Name in Apple Pay Sheet. Support for Pending Payment

### DIFF
--- a/ios/Classes/SwiftFlutterApplePayPlugin.swift
+++ b/ios/Classes/SwiftFlutterApplePayPlugin.swift
@@ -50,7 +50,7 @@ public class SwiftFlutterApplePayPlugin: NSObject, FlutterPlugin, PKPaymentAutho
             
             Stripe.setDefaultPublishableKey(stripePublishedKey)
             
-            let total = PKPaymentSummaryItem(label: "Total", amount: NSDecimalNumber(floatLiteral:totalPrice), type: .pending)
+            let total = PKPaymentSummaryItem(label: "Dorm Mom", amount: NSDecimalNumber(floatLiteral:totalPrice), type: .pending)
             items.append(total)
             
             paymentNeworks.forEach {

--- a/ios/Classes/SwiftFlutterApplePayPlugin.swift
+++ b/ios/Classes/SwiftFlutterApplePayPlugin.swift
@@ -39,12 +39,13 @@ public class SwiftFlutterApplePayPlugin: NSObject, FlutterPlugin, PKPaymentAutho
             guard let merchantIdentifier = arguments["merchantIdentifier"] as? String else {return}
             guard let merchantName = arguments["merchantName"] as? String else {return}
             guard let isPending = arguments["isPending"] as? Bool else {return}
-
+            
+            let type = isPending ? PKPaymentSummaryItemType.pending : PKPaymentSummaryItemType.final;
+            
             for dictionary in paymentItems {
                 guard let label = dictionary["label"] as? String else {return}
                 guard let price = dictionary["amount"] as? Double else {return}
-                let type = isPending ? PKPaymentSummaryItemType.pending : PKPaymentSummaryItemType.final;
-                
+
                 totalPrice += price
                 
                 items.append(PKPaymentSummaryItem(label: label, amount: NSDecimalNumber(floatLiteral: price), type: type))

--- a/ios/Classes/SwiftFlutterApplePayPlugin.swift
+++ b/ios/Classes/SwiftFlutterApplePayPlugin.swift
@@ -50,7 +50,7 @@ public class SwiftFlutterApplePayPlugin: NSObject, FlutterPlugin, PKPaymentAutho
             
             Stripe.setDefaultPublishableKey(stripePublishedKey)
             
-            let total = PKPaymentSummaryItem(label: "Dorm Mom", amount: NSDecimalNumber(floatLiteral:totalPrice), type: .pending)
+            let total = PKPaymentSummaryItem(label: "Total", amount: NSDecimalNumber(floatLiteral:totalPrice), type: .pending)
             items.append(total)
             
             paymentNeworks.forEach {

--- a/ios/Classes/SwiftFlutterApplePayPlugin.swift
+++ b/ios/Classes/SwiftFlutterApplePayPlugin.swift
@@ -41,7 +41,7 @@ public class SwiftFlutterApplePayPlugin: NSObject, FlutterPlugin, PKPaymentAutho
             for dictionary in paymentItems {
                 guard let label = dictionary["label"] as? String else {return}
                 guard let price = dictionary["amount"] as? Double else {return}
-                let type = PKPaymentSummaryItemType.pending
+                let type = PKPaymentSummaryItemType.final
                 
                 totalPrice += price
                 
@@ -50,7 +50,7 @@ public class SwiftFlutterApplePayPlugin: NSObject, FlutterPlugin, PKPaymentAutho
             
             Stripe.setDefaultPublishableKey(stripePublishedKey)
             
-            let total = PKPaymentSummaryItem(label: "Total", amount: NSDecimalNumber(floatLiteral:totalPrice), type: .pending)
+            let total = PKPaymentSummaryItem(label: "Total", amount: NSDecimalNumber(floatLiteral:totalPrice), type: .final)
             items.append(total)
             
             paymentNeworks.forEach {

--- a/ios/Classes/SwiftFlutterApplePayPlugin.swift
+++ b/ios/Classes/SwiftFlutterApplePayPlugin.swift
@@ -37,11 +37,13 @@ public class SwiftFlutterApplePayPlugin: NSObject, FlutterPlugin, PKPaymentAutho
             guard let stripePublishedKey = arguments["stripePublishedKey"] as? String else {return}
             guard let paymentItems = arguments["paymentItems"] as? [NSDictionary] else {return}
             guard let merchantIdentifier = arguments["merchantIdentifier"] as? String else {return}
-            
+            guard let merchantName = arguments["merchantName"] as? String else {return}
+            guard let isPending = arguments["isPending"] as? Bool else {return}
+
             for dictionary in paymentItems {
                 guard let label = dictionary["label"] as? String else {return}
                 guard let price = dictionary["amount"] as? Double else {return}
-                let type = PKPaymentSummaryItemType.final
+                let type = isPending ? PKPaymentSummaryItemType.pending : PKPaymentSummaryItemType.final;
                 
                 totalPrice += price
                 
@@ -50,7 +52,7 @@ public class SwiftFlutterApplePayPlugin: NSObject, FlutterPlugin, PKPaymentAutho
             
             Stripe.setDefaultPublishableKey(stripePublishedKey)
             
-            let total = PKPaymentSummaryItem(label: "Total", amount: NSDecimalNumber(floatLiteral:totalPrice), type: .final)
+            let total = PKPaymentSummaryItem(label: merchantName, amount: NSDecimalNumber(floatLiteral:totalPrice), type: type)
             items.append(total)
             
             paymentNeworks.forEach {

--- a/ios/Classes/SwiftFlutterApplePayPlugin.swift
+++ b/ios/Classes/SwiftFlutterApplePayPlugin.swift
@@ -41,7 +41,7 @@ public class SwiftFlutterApplePayPlugin: NSObject, FlutterPlugin, PKPaymentAutho
             for dictionary in paymentItems {
                 guard let label = dictionary["label"] as? String else {return}
                 guard let price = dictionary["amount"] as? Double else {return}
-                let type = PKPaymentSummaryItemType.final
+                let type = PKPaymentSummaryItemType.pending
                 
                 totalPrice += price
                 
@@ -50,7 +50,7 @@ public class SwiftFlutterApplePayPlugin: NSObject, FlutterPlugin, PKPaymentAutho
             
             Stripe.setDefaultPublishableKey(stripePublishedKey)
             
-            let total = PKPaymentSummaryItem(label: "Total", amount: NSDecimalNumber(floatLiteral:totalPrice), type: .final)
+            let total = PKPaymentSummaryItem(label: "Total", amount: NSDecimalNumber(floatLiteral:totalPrice), type: .pending)
             items.append(total)
             
             paymentNeworks.forEach {

--- a/lib/flutter_apple_pay.dart
+++ b/lib/flutter_apple_pay.dart
@@ -13,6 +13,8 @@ class FlutterApplePay {
     @required String currencyCode,
     @required List<PaymentNetwork> paymentNetworks,
     @required String merchantIdentifier,
+    @required String merchantName,
+    bool isPending = false,
     @required List<PaymentItem> paymentItems,
     @required String stripePublishedKey,
   }) async {
@@ -20,6 +22,7 @@ class FlutterApplePay {
     assert(currencyCode != null);
     assert(paymentItems != null);
     assert(merchantIdentifier != null);
+    assert(merchantName != null);
     assert(paymentItems != null);
     assert(stripePublishedKey != null);
 
@@ -31,7 +34,9 @@ class FlutterApplePay {
       'currencyCode': currencyCode,
       'paymentItems':
           paymentItems.map((PaymentItem item) => item._toMap()).toList(),
-      'merchantIdentifier': merchantIdentifier
+      'merchantIdentifier': merchantIdentifier,
+      'merchantName' : merchantName,
+      'isPending' : isPending
     };
     if (Platform.isIOS) {
       final dynamic stripeToken = await _channel.invokeMethod('getStripeToken', args);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_apple_pay
 description: Flutter Apple Pay
-version: 0.1.2
+version: 0.1.3
 author: Leonid Veremchuk<leonid.veremchuk@gmail.com>
 homepage: https://github.com/Snailapp
 


### PR DESCRIPTION
I submitted my app with the plugin but was rejected because the Apple Pay sheet did not have the Merchant Name.

So instead of "Pay Total", it will now say "Pay MERCHANTNAME" where MERCHANTNAME is a required parameter for the Merchant.

Original plugin only had "final" PaymentType but Apple Pay supports "Pending" payments. Added support for Pending Payments.